### PR TITLE
Allow to create mix packets using SURBs and then reflect them

### DIFF
--- a/sdk/rust/nym-sdk/examples/packet_factory_with_surbs.rs
+++ b/sdk/rust/nym-sdk/examples/packet_factory_with_surbs.rs
@@ -15,22 +15,27 @@ async fn main() {
     let bob_address = bob.nym_address();
     println!("bob_address={bob_address}");
 
-    // Alice creates packets for bob
+    // that's Charlie: they create the SURBS and later the packets
+    let charlie = mixnet::MixnetClient::connect_new().await.unwrap();
+    let charlie_address = charlie.nym_address();
+    println!("charlie_address={charlie_address}");
+
+    // Charlie (e.g. the discover node) creates some SURBs
+    let surbs = charlie.create_surbs(&bob_address, b"nonce".to_vec(), 5).await.unwrap();
+
+    // Alice then takes those SURBs and creates packets for Bob
     // (using a long message that requires fragmentation)
-    let packets = alice.create_mix_packet(
+    let packets = alice.create_mix_packet_with_surbs(
         [42u8; 4000],
-        &bob_address,
+        surbs,
     ).await.unwrap();
-    println!("{:?}", packets);
+    println!("packets={:?}", packets);
+
+    // Charlie then sends those packets to Bob (i.e. being a reflecting node)
 
     // serialize and deserialize
     let serialized_packets: Vec<Vec<u8>> = packets.into_iter().map(|x| x.into_bytes().unwrap()).collect();
     let packets = serialized_packets.into_iter().map(|x| MixPacket::try_from_bytes(x.as_slice()).unwrap()).collect();
-
-    // that's Charlie: they send the packets
-    let charlie = mixnet::MixnetClient::connect_new().await.unwrap();
-    let charlie_address = charlie.nym_address();
-    println!("charlie_address={charlie_address}");
 
     // let's do the actual sending
     charlie.send_packets(packets).await;


### PR DESCRIPTION
See included example

```
alice_address=4TNNcGgFEAp3nsRTGRjtSGcnwWQcW3AXC8X8M3RNAwkQ.DXz2yy4xtZ5Nrc2gaSihRTkJXGWrAhaoeLmUSwUhr9wB@AJad2R9virYEYXEsTcicN5y5tyPoixrhhAGsxoESZVnc
bob_address=GYe7iQT1ytf4WwBXRDn5TSNAekarmVsAnVDL5Cd6tRGi.EZy3AZYB3fiJUEW39mU1YZanu8hcJCgk1uBB9ZjDaeJB@E3mvZTHQCdBvhfr178Swx9g4QG3kkRUun7YnToLMcMbM
charlie_address=6XN81m2hmNApA3L8N9hrfdYNviUqkgUjWVhuL4LJyKcK.AnQU7kSQzsDR5idpJuhMEbHE6gearT1M9EV3PQyPPN5A@9Byd9VAtyYMnbVAcqdoQxJnq76XEg2dbxbiF5Aa5Jj9J
packets=[MixPacket to NymNodeRoutingAddress(200.58.103.141:1789) with packet_type Mix. Packet NymPacket::Sphinx { len: 2413 }, MixPacket to NymNodeRoutingAddress(49.12.68.22:1789) with packet_type Mix. Packet NymPacket::Sphinx { len: 2413 }, MixPacket to NymNodeRoutingAddress(38.242.151.1:1789) with packet_type Mix. Packet NymPacket::Sphinx { len: 2413 }]
Received: ****************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
```